### PR TITLE
fix: add Vercel SPA routing configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Add vercel.json to handle client-side routing for React Router.

This fixes 404 errors when directly accessing or refreshing URLs like:
- /projects/:id
- /neural-notes/:slug

The rewrite rule ensures all routes are served through index.html, allowing React Router to handle routing on the client side.

Fixes #51

---

Generated with [Claude Code](https://claude.ai/code)