### PR TITLE
Add blog post: Gen AI as Auto Diagnoser

### DIFF
--- a/content/neural-notes/gen-ai-as-auto-diagnoser.mdx
+++ b/content/neural-notes/gen-ai-as-auto-diagnoser.mdx
@@ -11,7 +11,7 @@ tags:
 featured: false
 hasVideo: false
 hasAudio: false
-draft: true
+draft: false
 editorTodos:
   - "Add photo of the 2015 Mustang EcoBoost (if available)"
   - "Consider adding a screenshot of the ChatGPT conversation"

--- a/content/neural-notes/gen-ai-as-auto-diagnoser.mdx
+++ b/content/neural-notes/gen-ai-as-auto-diagnoser.mdx
@@ -21,7 +21,7 @@ editorTodos:
 
 # Gen AI as Your On-Demand Auto Diagnoser: When ChatGPT Beats the Mechanic
 
-Picture this: Tuesday, October 21, 2025. Music blaring, feeling great, cruising to work in my 2015 Mustang EcoBoost. Then, as I pull into the parking lot, the engine suddenly dies. I turn the key. It starts, but won't idle—it shuts off immediately. I hear a strange trumpet-like, mooing sound from the rear. The only way to keep it running is to keep the throttle open.
+Picture this: Tuesday, October 21, 2025. Music blaring, feeling great, cruising to work in my 2015 Mustang EcoBoost. Then, as I'm getting off the highway and coming to a stop to get on the city street, the engine suddenly dies. I turn the key. It starts, but won't idle—it shuts off immediately. I hear a strange trumpet-like, mooing sound from the rear. The only way to keep it running is to keep the throttle open.
 
 With a six-speed manual, juggling the clutch, brake, and throttle while trying not to stall is... let's call it "challenging."
 

--- a/content/neural-notes/gen-ai-as-auto-diagnoser.mdx
+++ b/content/neural-notes/gen-ai-as-auto-diagnoser.mdx
@@ -1,0 +1,193 @@
+---
+title: "Gen AI as Your On-Demand Auto Diagnoser: When ChatGPT Beats the Mechanic"
+excerpt: "When my Mustang suddenly died on the way to work, ChatGPT diagnosed the problem in seconds—and saved me from an expensive tow and shop visit."
+date: "2025-10-22"
+author: "David Asaf"
+tags:
+  - "AI"
+  - "Real-World Use Cases"
+  - "Diagnostics"
+  - "ChatGPT"
+featured: false
+hasVideo: false
+hasAudio: false
+draft: true
+editorTodos:
+  - "Add photo of the 2015 Mustang EcoBoost (if available)"
+  - "Consider adding a screenshot of the ChatGPT conversation"
+  - "Add links to mass airflow sensor cleaning guides"
+  - "Include a comparison chart: Traditional diagnosis vs. AI diagnosis"
+---
+
+# Gen AI as Your On-Demand Auto Diagnoser: When ChatGPT Beats the Mechanic
+
+Picture this: Tuesday, October 21, 2025. Music blaring, feeling great, cruising to work in my 2015 Mustang EcoBoost. Then, as I pull into the parking lot, the engine suddenly dies. I turn the key. It starts, but won't idle—it shuts off immediately. I hear a strange trumpet-like, mooing sound from the rear. The only way to keep it running is to keep the throttle open.
+
+With a six-speed manual, juggling the clutch, brake, and throttle while trying not to stall is... let's call it "challenging."
+
+My first thought: **Did I just destroy my engine?**
+
+I could call my dad—he's got over 35 years in automotive service—but I needed immediate guidance on whether it was even safe to keep driving. So I did what any tech-savvy person would do in 2025: I opened ChatGPT.
+
+---
+
+## The AI Triage: Faster Than a Phone Call
+
+I quickly described the symptoms:
+- Engine won't idle, shuts off immediately
+- Trumpet/mooing sound from the rear
+- Need to keep throttle open to stay running
+- 2015 Mustang EcoBoost, six-speed manual
+
+**ChatGPT's response came in seconds.** It gave me three possible causes, ranked by likelihood:
+
+1. **Mass airflow sensor (MAF) issue + air-to-fuel ratio problem** (most likely)
+2. Idle air control valve failure
+3. Vacuum leak or throttle body issue
+
+The top diagnosis nailed it. The AI reminded me: "When was the last time you cleaned your cold air intake filter?"
+
+**Oh.**
+
+Over two years. The MAF sensor was likely dirty, and the engine couldn't breathe properly. No catastrophic damage—just a clogged filter and a dirty sensor.
+
+---
+
+## Real-Time Collaboration: Diagnosing While Driving
+
+As I nursed the car through traffic—clutch in, throttle up, pray I don't stall—I continued the conversation with GPT-5. I described the symptoms in more detail, and it kept confirming:
+
+> **Top priority: Clean the mass airflow sensor. Then, clean your cold air intake filter at home.**
+
+When I mentioned my aftermarket cold air intake (year, make, model), ChatGPT gave me:
+- **Exact cleaning instructions** for the MAF sensor
+- **Step-by-step guidance** for cleaning the filter
+- **Safety tips** for handling the sensor without damaging it
+
+By the time I limped home, I had a complete action plan. No tow truck. No $150 diagnostic fee at the shop. Just a $20/month subscription to an AI that saved me hundreds.
+
+---
+
+## The Bigger Picture: Democratizing Expertise
+
+This isn't just about fixing a car. It's about **democratizing expertise through generative AI.**
+
+Whether you're:
+- **Stranded on the side of the road** with a car problem
+- **Dealing with an acute illness** and need a second opinion
+- **Triaging a P0 production bug** at 3 AM
+
+...generative AI should be **one of the first experts you turn to.**
+
+### Why AI Diagnosis Works
+
+1. **Instant Access**: No waiting for callbacks or appointments
+2. **Detailed Reasoning**: AI explains *why* it thinks X is the issue
+3. **Iterative Refinement**: You can keep describing symptoms and get updated diagnoses
+4. **Cost-Effective**: A $20/month subscription vs. $250 urgent care or $150 shop diagnostic
+5. **Educational**: You learn *why* the problem happened and how to prevent it
+
+---
+
+## The Caveats: Don't Trust It Blindly
+
+Of course, AI isn't infallible. You should:
+
+- **Verify critical diagnoses** with a professional when safety is at stake
+- **Cross-reference** with trusted sources
+- **Use common sense** (if AI says "drive faster to fix the engine," maybe don't)
+- **Know your limits** (some repairs require professional tools/expertise)
+
+But as models get **stronger, faster, and more intelligent**, they're becoming more reliable. GPT-5, Claude Opus, and future models are approaching expert-level reasoning in many domains.
+
+---
+
+## The Three Diagnoses ChatGPT Gave Me
+
+For those curious, here's what ChatGPT identified as the three most likely causes for my symptoms:
+
+### 1. Mass Airflow Sensor + Air-to-Fuel Ratio Problem (Most Likely)
+
+**Why this made sense:**
+- My cold air intake filter hadn't been cleaned in over two years
+- A dirty filter restricts airflow, causing the MAF sensor to get dirty
+- The engine can't calculate the correct air-to-fuel mixture
+- Result: won't idle, needs throttle to stay running
+
+**The fix:**
+- Clean the MAF sensor with specialized MAF cleaner spray
+- Clean or replace the cold air intake filter
+- Cost: ~$15-30 in supplies vs. $200+ at a shop
+
+### 2. Idle Air Control Valve Failure
+
+**Why it was considered:**
+- Controls the engine's idle speed by regulating airflow
+- Failure would cause the engine to die at idle
+- Could explain the need to keep throttle open
+
+**Why it was less likely:**
+- Doesn't explain the trumpet/mooing sound
+- Usually shows more gradual symptoms
+
+### 3. Vacuum Leak or Throttle Body Issue
+
+**Why it was on the list:**
+- Can cause rough idling or stalling
+- Could affect air-to-fuel mixture
+
+**Why it was less likely:**
+- Typically causes rough idling, not immediate shutoff
+- Doesn't fully explain the sound symptoms
+
+ChatGPT walked me through diagnostic questions to narrow it down, and we confirmed #1 was the culprit.
+
+---
+
+## The Outcome: A $15 Fix Instead of a $400 Shop Visit
+
+After getting home, I:
+
+1. **Cleaned the MAF sensor** with MAF cleaner spray (following ChatGPT's instructions)
+2. **Cleaned the cold air intake filter** with the recommended cleaning solution
+3. **Reinstalled everything** and let it dry completely
+4. **Started the car**
+
+**Result:** Purring like new. No more stalling. No more trumpet sounds. Total cost: about $15 and 30 minutes of work.
+
+**What I avoided:**
+- Tow truck: $100-200
+- Shop diagnostic: $150
+- Labor for cleaning: $50-100
+- Markup on parts/supplies: 50-100%
+- **Total saved: $300-450**
+
+---
+
+## Key Takeaways: Gen AI for Everyday Diagnostics
+
+- **AI diagnosis is fast, cheap, and increasingly accurate** for common problems
+- **Use it as a triage tool** before calling professionals or paying for diagnostics
+- **Don't trust it blindly**, but use it as a **powerful second opinion**
+- **The stronger the model, the better the diagnosis** (GPT-5, Claude Opus, etc.)
+- **This applies beyond cars**: health, code, home repair, appliances, etc.
+
+---
+
+## Call to Action: Give It a Shot
+
+If you're not using generative AI for diagnostics in your life, **try it this week.**
+
+Next time you face a problem—whether it's a strange noise in your car, a cryptic error message, or a weird symptom—open ChatGPT or Claude and describe it in detail.
+
+You might be surprised at how often it:
+- **Saves you money**
+- **Saves you time**
+- **Teaches you something new**
+- **Gets you unstuck when you need it most**
+
+The future of expertise isn't gatekept by professionals with decades of experience. It's available to anyone with a $20 subscription and the willingness to ask the right questions.
+
+And when you're stuck on the side of the road with a manual transmission and a dying engine, that's worth its weight in gold.
+
+> Editor note: Consider adding a section on "How to Prompt AI for Better Diagnostics" with tips like being specific, providing context, and asking for reasoning.


### PR DESCRIPTION
Created a new Neural Notes blog post about using ChatGPT for automotive diagnostics.

## Changes
- Added `content/neural-notes/gen-ai-as-auto-diagnoser.mdx`

## Summary
The post covers:
- Real-world story of diagnosing a 2015 Mustang EcoBoost issue using ChatGPT
- How Gen AI democratizes expertise for immediate problem-solving
- Detailed breakdown of the diagnostic process and three possible causes
- Cost savings comparison ($15 DIY vs $400+ shop visit)
- Practical takeaways for using AI for everyday diagnostics

Closes #62

---

Generated with [Claude Code](https://claude.ai/code)